### PR TITLE
Support extra parameters for the ssm-session command.

### DIFF
--- a/ssm_tools/ssm_session_cli.py
+++ b/ssm_tools/ssm_session_cli.py
@@ -66,11 +66,9 @@ def start_session(instance_id, extras, profile=None, region=None):
     if region:
         extra_args += f"--region {region} "
 
-    parameters = ""
-    for extra in extras:
-        parameters += f" {extra}"
+    parameters = " ".join(extras)
 
-    command = f'aws {extra_args} ssm start-session --target {instance_id}{parameters}'
+    command = f'aws {extra_args} ssm start-session --target {instance_id} {parameters}'
     logger.info("Running: %s", command)
     os.system(command)
 


### PR DESCRIPTION
Based on:
  - https://github.com/mludvig/aws-utils/pull/2 from @aws-taylor.
  - https://github.com/aws/amazon-ssm-agent/issues/131#issuecomment-622957074 from @AndreCouture

Example:

```shell
ssm-session my-instance.hostname --document-name AWS-StartInteractiveCommand --parameters command='["sudo -i -u myuser"]'
```