### PR TITLE
Ec2 instance connect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ packaging
 
 # AWS Stuff
 botocore
-boto3
+boto3 >= 1.22.0

--- a/ssm_tools/common.py
+++ b/ssm_tools/common.py
@@ -140,7 +140,7 @@ __all__.append("AWSSessionBase")
 class AWSSessionBase:
     def __init__(self, args):
         # aws-cli compatible MFA cache
-        cli_cache = pathlib.Path('~/.aws/cli/cache').expanduser().name
+        cli_cache = pathlib.Path('~/.aws/cli/cache').expanduser()
 
         # Construct boto3 session with MFA cache
         self.session = boto3.session.Session(profile_name=args.profile, region_name=args.region)

--- a/ssm_tools/common.py
+++ b/ssm_tools/common.py
@@ -1,7 +1,11 @@
 import sys
+import pathlib
 import logging
 import subprocess
+
 import boto3
+import botocore.credentials
+
 import packaging.version
 from . import __version__ as ssm_tools_version
 
@@ -129,3 +133,15 @@ def verify_plugin_version(version_required, logger):
     logger.error("ERROR: Check out https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html for instructions")
 
     return False
+
+# ---------------------------------------------------------
+
+__all__.append("AWSSessionBase")
+class AWSSessionBase:
+    def __init__(self, args):
+        # aws-cli compatible MFA cache
+        cli_cache = pathlib.Path('~/.aws/cli/cache').expanduser().name
+
+        # Construct boto3 session with MFA cache
+        self.session = boto3.session.Session(profile_name=args.profile, region_name=args.region)
+        self.session._session.get_component('credential_provider').get_provider('assume-role').cache = botocore.credentials.JSONFileCache(cli_cache)

--- a/ssm_tools/ec2_instance_connect.py
+++ b/ssm_tools/ec2_instance_connect.py
@@ -1,0 +1,104 @@
+import sys
+import logging
+import pathlib
+import subprocess
+
+from typing import List
+
+import botocore.exceptions
+from .common import AWSSessionBase
+
+logger = logging.getLogger("ssm-tools.ec2-instance-connect")
+
+class EC2InstanceConnectHelper(AWSSessionBase):
+    def __init__(self, args: list):
+        super().__init__(args)
+
+        # Create boto3 client from session
+        self.ec2ic_client = self.session.client('ec2-instance-connect')
+
+    def obtain_ssh_key(self, key_file_name: str) -> str:
+        def _read_ssh_agent_keys() -> List[str]:
+            cp = subprocess.run(["ssh-add", "-L"], stdout=subprocess.PIPE)
+            if cp.returncode != 0:
+                logger.debug("Failed to run: ssh-add -L")
+                return []
+            return cp.stdout.decode('utf-8').split('\n')
+
+        def _read_ssh_public_key(key_file_name_pub: str) -> str:
+            try:
+                pub_key_raw = pathlib.Path(key_file_name_pub).expanduser().read_text().split("\n")
+                for line in pub_key_raw:
+                    if line.startswith("ssh-"):
+                        return line
+            except (FileNotFoundError, PermissionError) as ex:
+                logger.debug("Could not read the public key: %s", ex)
+            return ""
+
+        if not key_file_name:
+            # No key_file_name was specified, try ...
+            # - SSH Agent keys (doesn't matter which one - we'll immediately connect to it)
+            ssh_keys = _read_ssh_agent_keys()
+            if ssh_keys:
+                logger.info("Using SSH key from SSH Agent, should be as good as any.")
+                return ssh_keys[0]
+
+            # - ~/.ssh/id_rsa.pub
+            ssh_key = _read_ssh_public_key("~/.ssh/id_rsa.pub")
+            if ssh_key:
+                logger.info("Using SSH key from ~/.ssh/id_rsa.pub - should work in most cases")
+                return ssh_key
+
+            # - ~/.ssh/id_dsa.pub
+            ssh_key = _read_ssh_public_key("~/.ssh/id_dsa.pub")
+            if ssh_key:
+                logger.info("Using SSH key from ~/.ssh/id_dsa.pub - should work in most cases")
+                return ssh_key
+
+        else:   # i.e. key_file_name is set
+            logger.info("Looking for a public key matching: %s", key_file_name)
+
+            # Try reading the public key file (key_file_name + ".pub" suffix)
+            key_file_name_pub = key_file_name + ".pub"
+            ssh_key = _read_ssh_public_key(key_file_name_pub)
+            if ssh_key:
+                logger.info("Found a matching SSH Public Key in %s", key_file_name_pub)
+                return ssh_key
+
+            # Try reading the public key from SSH Agent
+            for line in _read_ssh_agent_keys():
+                if line.endswith(key_file_name):
+                    logger.info("Found a matching SSH Public Key through SSH Agent")
+                    return line
+            logger.debug("Could not find the public key for %s in SSH Agent", key_file_name)
+
+            # Try extracting the public key from the provided private key
+            logger.warning("Trying to extract the public key from %s - you may be asked for a passphrase!", key_file_name)
+            cp = subprocess.run(["ssh-keygen", "-y", "-f", key_file_name], stdout=subprocess.PIPE)
+            if cp.returncode == 0:
+                logger.info("Extracted the public key from: %s", key_file_name)
+                return cp.stdout.decode('utf-8').split('\n')[0]
+            logger.debug("Could not extract the public key from %s", key_file_name)
+
+        logger.warning("Unable to find SSH public key from any available source.")
+        logger.warning("Use --debug for more details on what we tried.")
+        sys.exit(1)
+
+
+    def send_ssh_key(self, instance_id: str, login_name: str, key_file_name: str) -> None:
+        if not login_name:
+            logger.error("Unable to figure out the EC2 login name. Use \"-l {user}\" or {user}@{instance}.")
+            sys.exit(1)
+
+        ssh_key = self.obtain_ssh_key(key_file_name)
+        logger.debug("SSH Key: %s", ssh_key)
+
+        result = self.ec2ic_client.send_ssh_public_key(
+            InstanceId=instance_id,
+            InstanceOSUser=login_name,
+            SSHPublicKey=ssh_key,
+        )
+
+        if not result['Success']:
+            logger.error("Failed to send SSH Key to %s", instance_id)
+            sys.exit(1)

--- a/ssm_tools/resolver.py
+++ b/ssm_tools/resolver.py
@@ -1,26 +1,14 @@
 #!/usr/bin/env python3
 
-import os
 import sys
 import re
 import logging
-import botocore.credentials
 import botocore.session
-import boto3
+from .common import AWSSessionBase
 
 logger = logging.getLogger("ssm-tools.resolver")
 
-class CommonResolver():
-    def __init__(self, args):
-        # aws-cli compatible MFA cache
-        cli_cache = os.path.join(os.path.expanduser('~'),'.aws/cli/cache')
-
-        # Construct boto3 session with MFA cache
-        self.session = boto3.session.Session(profile_name=args.profile, region_name=args.region)
-        self.session._session.get_component('credential_provider').get_provider('assume-role').cache = botocore.credentials.JSONFileCache(cli_cache)
-
-
-class InstanceResolver(CommonResolver):
+class InstanceResolver(AWSSessionBase):
     def __init__(self, args):
         super().__init__(args)
 
@@ -170,7 +158,7 @@ class InstanceResolver(CommonResolver):
         # Found only one instance - return it
         return instances[0]
 
-class ContainerResolver(CommonResolver):
+class ContainerResolver(AWSSessionBase):
     def __init__(self, args):
         super().__init__(args)
 

--- a/ssm_tools/ssm_ssh_cli.py
+++ b/ssm_tools/ssm_ssh_cli.py
@@ -73,7 +73,7 @@ def start_ssh_session(ssh_args: list, profile: str = None, region: str = None):
         aws_args += f"--region {region} "
     proxy_option = ["-o", f"ProxyCommand=aws {aws_args} ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p"]
     command = ["ssh"] + proxy_option + ssh_args
-    logger.info("Running: %s", command)
+    logger.debug("Running: %s", command)
     os.execvp(command[0], command)
 
 def main():


### PR DESCRIPTION
Added `ssm-ssh` support for sending the SSH keys to EC2 metadata through EC2 Instance Connect.

This allows individual IAM users to use their own SSH keys instead of having to share the instance "Key Pair".

Usage `ssm-ssh --send-key`. The key name will be inferred from the supplied ssh parameters or attempted to figure out from one of the default places, including SSH Agent.