### PR TITLE
ignore ssh-agent, ssh-keygen utf-8 decode failures

### DIFF
--- a/ssm_tools/ec2_instance_connect.py
+++ b/ssm_tools/ec2_instance_connect.py
@@ -25,9 +25,9 @@ class EC2InstanceConnectHelper(AWSSessionBase):
         def _read_ssh_agent_keys() -> List[str]:
             cp = subprocess.run(["ssh-add", "-L"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
             if cp.returncode != 0:
-                logger.debug("Failed to run: ssh-add -L: %s", cp.stderr.decode("utf-8", errors='ignore').strip().replace("\n", " "))
+                logger.debug("Failed to run: ssh-add -L: %s", cp.stderr.decode("utf-8", errors="ignore").strip().replace("\n", " "))
                 return []
-            return cp.stdout.decode("utf-8", errors='ignore').split("\n")
+            return cp.stdout.decode("utf-8", errors="ignore").split("\n")
 
         def _read_ssh_public_key(key_file_name_pub: str) -> str:
             try:
@@ -86,7 +86,7 @@ class EC2InstanceConnectHelper(AWSSessionBase):
             cp = subprocess.run(["ssh-keygen", "-y", "-f", key_file_name], stdout=subprocess.PIPE, check=False)
             if cp.returncode == 0:
                 logger.info("Extracted the public key from: %s", key_file_name)
-                return cp.stdout.decode("utf-8", errors='ignore').split("\n")[0], key_file_name
+                return cp.stdout.decode("utf-8", errors="ignore").split("\n")[0], key_file_name
             logger.debug("Could not extract the public key from %s", key_file_name)
 
         logger.warning("Unable to find SSH public key from any available source.")


### PR DESCRIPTION
In my environment I have a smart card (PKCS11) that holds my private keys; for reasons I cannot change the comment field includes bytes that cannot be decoded into `utf-8`.

The comment field is useful but not essential for the SSM API call `SendSSHPublicKey`. This PR sets the `bytes.decode()` calls to to ignore any `utf-8` decoding errors.