### PR TITLE
fix: KeyError: 'AvailabilityZone' for managed instances

### DIFF
--- a/ssm_tools/resolver.py
+++ b/ssm_tools/resolver.py
@@ -129,8 +129,9 @@ class InstanceResolver(AWSSessionBase):
         items_list.sort(key=lambda x: x.get("InstanceName") or x.get("HostName"))  # type: ignore
 
         for instance in items_list:
-            instance["Addresses"] = ", ".join(instance["Addresses"])
-            del instance["AvailabilityZone"]
+            if isinstance(instance.get("Addresses"), (list, tuple)):
+                instance["Addresses"] = ", ".join([a for a in instance["Addresses"] if a])
+            instance.pop("AvailabilityZone", None)
 
         table = tabulate(items_list, headers="keys")
         if not quiet:


### PR DESCRIPTION
I have AWS SSM Fleet Manager Managed Instances in my inventory. Since v2.0.1, `ec2-session --list` crashes with:
```
$ ec2-session --list
Traceback (most recent call last):
  File "/home/leon/.local/bin/ec2-session", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/leon/.local/pipx/venvs/aws-ssm-tools/lib/python3.13/site-packages/ssm_tools/ssm_session_cli.py", line 154, in main
    InstanceResolver(args).print_list()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/leon/.local/pipx/venvs/aws-ssm-tools/lib/python3.13/site-packages/ssm_tools/resolver.py", line 133, in print_list
    del instance["AvailabilityZone"]
        ~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'AvailabilityZone'
```

The 2.0.x refactor added AvailabilityZone for EC2 instances and then unconditionally deleted the key when formatting the table. Managed / hybrid instances never receive AvailabilityZone, causing a KeyError on del. This change replaces del with pop(..., None) and safely normalizes Addresses (filters out empty values, joins into a string). No behavioral change for valid EC2 instances; output is unchanged except the error is eliminated.

Tested by running `ec2-session --list` and confirming the table renders without exceptions for mixed EC2 and managed instances.