### PR TITLE
Windows menu + AWS SSO Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ and for ECS Docker Exec: `ecs-session`
     00:00:15 | In:  156.0 B @    5.2 B/s | Out:  509.0 B @   40.4 B/s
     ```
 
+    Enter your local computer password if prompted.
     Leave it running and from another shell `ssh` to one of the instances listed
     with `--list` above. For example to `test1` that's got VPC IP `192.168.45.158`:
 
@@ -260,17 +261,17 @@ Follow the detailed instructions at [**Using SSM Session Manager for
 interactive instance access**](https://aws.nz/best-practice/ssm-session-manager/)
 for more informations.
 
-### Install *AWS CLI* and `session-manager-plugin`
+### Install *AWS CLI 2* and `session-manager-plugin`
 
 Make sure you've got `aws` and `session-manager-plugin` installed locally
 on your laptop.
 
 ```
 ~ $ aws --version
-aws-cli/1.18.31 Python/3.6.9 Linux/5.3.0-42-generic botocore/1.15.31
+aws-cli/2.27.63 Python/3.13.5 Darwin/24.6.0 source/arm64
 
 ~ $ session-manager-plugin --version
-1.1.56.0
+1.2.707.0
 ```
 
 Follow [AWS CLI installation

--- a/ssm_tools/ecs_session_cli.py
+++ b/ssm_tools/ecs_session_cli.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, check_aws_login, target_selector
+from .common import add_general_parameters, check_aws_login, configure_logging, show_version, target_selector
 from .resolver import ContainerResolver
 
 logger = logging.getLogger("ssm-tools.ecs-session")

--- a/ssm_tools/ecs_session_cli.py
+++ b/ssm_tools/ecs_session_cli.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, target_selector
+from .common import add_general_parameters, configure_logging, show_version, sso_login, target_selector
 from .resolver import ContainerResolver
 
 logger = logging.getLogger("ssm-tools.ecs-session")
@@ -107,6 +107,8 @@ def execute_command(container: dict[str, Any], args: argparse.Namespace, command
 def main() -> int:
     ## Split command line to main args and optional command to run
     args, _ = parse_args(sys.argv[1:])
+
+    sso_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ecs_session_cli.py
+++ b/ssm_tools/ecs_session_cli.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, sso_login, target_selector
+from .common import add_general_parameters, configure_logging, show_version, check_aws_login, target_selector
 from .resolver import ContainerResolver
 
 logger = logging.getLogger("ssm-tools.ecs-session")
@@ -108,7 +108,7 @@ def main() -> int:
     ## Split command line to main args and optional command to run
     args, _ = parse_args(sys.argv[1:])
 
-    sso_login(args.profile)
+    check_aws_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_session_cli.py
+++ b/ssm_tools/ssm_session_cli.py
@@ -19,7 +19,7 @@ import sys
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, check_aws_login, target_selector
+from .common import add_general_parameters, check_aws_login, configure_logging, show_version, target_selector
 from .resolver import InstanceResolver
 
 logger = logging.getLogger("ssm-tools.ec2-session")

--- a/ssm_tools/ssm_session_cli.py
+++ b/ssm_tools/ssm_session_cli.py
@@ -19,7 +19,7 @@ import sys
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, sso_login, target_selector
+from .common import add_general_parameters, configure_logging, show_version, check_aws_login, target_selector
 from .resolver import InstanceResolver
 
 logger = logging.getLogger("ssm-tools.ec2-session")
@@ -147,7 +147,7 @@ def main() -> int:
     ## Split command line to main args and optional command to run
     args = parse_args(sys.argv[1:])
 
-    sso_login(args.profile)
+    check_aws_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_session_cli.py
+++ b/ssm_tools/ssm_session_cli.py
@@ -19,7 +19,7 @@ import sys
 
 import botocore.exceptions
 
-from .common import add_general_parameters, configure_logging, show_version, target_selector
+from .common import add_general_parameters, configure_logging, show_version, sso_login, target_selector
 from .resolver import InstanceResolver
 
 logger = logging.getLogger("ssm-tools.ec2-session")
@@ -146,6 +146,8 @@ def start_session(instance_id: str, args: argparse.Namespace) -> None:
 def main() -> int:
     ## Split command line to main args and optional command to run
     args = parse_args(sys.argv[1:])
+
+    sso_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_ssh_cli.py
+++ b/ssm_tools/ssm_ssh_cli.py
@@ -21,7 +21,7 @@ from .common import (
     add_general_parameters,
     configure_logging,
     show_version,
-    sso_login,
+    check_aws_login,
     target_selector,
     verify_awscli_version,
     verify_plugin_version,
@@ -127,7 +127,7 @@ def main() -> int:
     if args.log_level == logging.DEBUG:
         extra_args.append("-v")
 
-    sso_login(args.profile)
+    check_aws_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_ssh_cli.py
+++ b/ssm_tools/ssm_ssh_cli.py
@@ -21,6 +21,7 @@ from .common import (
     add_general_parameters,
     configure_logging,
     show_version,
+    sso_login,
     target_selector,
     verify_awscli_version,
     verify_plugin_version,
@@ -125,6 +126,8 @@ def main() -> int:
 
     if args.log_level == logging.DEBUG:
         extra_args.append("-v")
+
+    sso_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_ssh_cli.py
+++ b/ssm_tools/ssm_ssh_cli.py
@@ -19,9 +19,9 @@ import botocore.exceptions
 
 from .common import (
     add_general_parameters,
+    check_aws_login,
     configure_logging,
     show_version,
-    check_aws_login,
     target_selector,
     verify_awscli_version,
     verify_plugin_version,

--- a/ssm_tools/ssm_tunnel_cli.py
+++ b/ssm_tools/ssm_tunnel_cli.py
@@ -28,10 +28,10 @@ import pexpect
 from .common import (
     add_general_parameters,
     bytes_to_human,
+    check_aws_login,
     configure_logging,
     seconds_to_human,
     show_version,
-    check_aws_login,
     target_selector,
 )
 from .resolver import InstanceResolver

--- a/ssm_tools/ssm_tunnel_cli.py
+++ b/ssm_tools/ssm_tunnel_cli.py
@@ -31,7 +31,7 @@ from .common import (
     configure_logging,
     seconds_to_human,
     show_version,
-    sso_login,
+    check_aws_login,
     target_selector,
 )
 from .resolver import InstanceResolver
@@ -376,7 +376,7 @@ def main() -> int:
     ## Split command line args
     args = parse_args(sys.argv[1:])
 
-    sso_login(args.profile)
+    check_aws_login(args.profile)
 
     configure_logging(args.log_level)
 

--- a/ssm_tools/ssm_tunnel_cli.py
+++ b/ssm_tools/ssm_tunnel_cli.py
@@ -31,6 +31,7 @@ from .common import (
     configure_logging,
     seconds_to_human,
     show_version,
+    sso_login,
     target_selector,
 )
 from .resolver import InstanceResolver
@@ -374,6 +375,8 @@ def main() -> int:
 
     ## Split command line args
     args = parse_args(sys.argv[1:])
+
+    sso_login(args.profile)
 
     configure_logging(args.log_level)
 


### PR DESCRIPTION
This PR addresses these issues https://github.com/mludvig/aws-ssm-tools/issues/54 https://github.com/mludvig/aws-ssm-tools/issues/53 https://github.com/mludvig/aws-ssm-tools/issues/4

The simple terminal menu only supports Mac and Linux, so as a fallback, I've updated the code to print a numbered tabulate table, which waits for a user input for what server to connect to. 

If the user's AWS SSO credentials have expired or they have not run `aws sso login`, we currently pass back a complicated traceback that looks like an issue with the SSM tools. This change catches those errors that can be fixed with a simple `aws sso login` command and runs it for the user.

Feel free to tweak the code as needed these were only some quick fixes for things I ran into.